### PR TITLE
fix: database path & improve CI caching for Azure Static Web Apps

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -124,6 +124,11 @@ jobs:
 
       - name: Install Project Dependencies
         run: pnpm install --dev --ignore-scripts
+      - name: Cache Azure Static Web Apps CLI Downloaded Files
+        uses: actions/cache@v4.2.0
+        with:
+          key: swa-${{ runner.arch }}-${{ runner.os }}
+          path: ~/.swa
 
       - name: Download Docs Output
         uses: actions/download-artifact@v4.3.0

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -5,6 +5,9 @@ export default defineNuxtConfig({
     applicationinsights: {
       connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
     },
+    content: {
+      database: { type: 'sqlite', filename: '/tmp/contents.sqlite' },
+    },
   },
   compatibilityDate: '2024-07-11',
   nitro: {
@@ -23,10 +26,6 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
   content: {
     build: { markdown: { toc: { searchDepth: 1 } } },
-    database: {
-      type: 'sqlite',
-      filename: process.env.NUXT_CONTENT_DB_PATH || './.nuxt/contents.sqlite',
-    },
     preview: { api: 'https://api.nuxt.studio' },
   },
   icon: {


### PR DESCRIPTION
Set a constant database path to resolve 500 errors on POST requests and add caching for Azure Static Web Apps CLI downloaded files in the CI workflow.